### PR TITLE
Use $crate in the command macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ A basic ping-pong bot looks like:
 ```rust,no-run
 extern crate serenity;
 
-use serenity::client::{Client, Context};
-use serenity::model::Message;
+use serenity::client::Client;
 use std::env;
 
 fn main() {

--- a/examples/07_voice/src/main.rs
+++ b/examples/07_voice/src/main.rs
@@ -10,7 +10,7 @@
 #[macro_use]
 extern crate serenity;
 
-use serenity::client::{CACHE, Client, Context};
+use serenity::client::{CACHE, Client};
 use serenity::ext::voice;
 use serenity::model::{ChannelId, Message, Mentionable};
 use serenity::Result as SerenityResult;

--- a/src/ext/framework/mod.rs
+++ b/src/ext/framework/mod.rs
@@ -113,28 +113,28 @@ use ::client::CACHE;
 #[macro_export]
 macro_rules! command {
     ($fname:ident($c:ident) $b:block) => {
-        pub fn $fname($c: &Context, _: &Message, _: Vec<String>) -> Result<(), String> {
+        pub fn $fname($c: &$crate::client::Context, _: &$crate::model::Message, _: Vec<String>) -> Result<(), String> {
             $b
 
             Ok(())
         }
     };
     ($fname:ident($c:ident, $m:ident) $b:block) => {
-        pub fn $fname($c: &Context, $m: &Message, _: Vec<String>) -> Result<(), String> {
+        pub fn $fname($c: &$crate::client::Context, $m: &$crate::model::Message, _: Vec<String>) -> Result<(), String> {
             $b
 
             Ok(())
         }
     };
     ($fname:ident($c:ident, $m:ident, $a:ident) $b:block) => {
-        pub fn $fname($c: &Context, $m: &Message, $a: Vec<String>) -> Result<(), String> {
+        pub fn $fname($c: &$crate::client::Context, $m: &$crate::model::Message, $a: Vec<String>) -> Result<(), String> {
             $b
 
             Ok(())
         }
     };
     ($fname:ident($c:ident, $m:ident, $a:ident, $($name:ident: $t:ty),*) $b:block) => {
-        pub fn $fname($c: &Context, $m: &Message, $a: Vec<String>) -> Result<(), String> {
+        pub fn $fname($c: &$crate::client::Context, $m: &$crate::model::Message, $a: Vec<String>) -> Result<(), String> {
             let mut i = $a.iter();
             let mut arg_counter = 0;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,8 +36,7 @@
 //! ```rust,ignore
 //! extern crate serenity;
 //!
-//! use serenity::client::{Client, Context};
-//! use serenity::model::Message;
+//! use serenity::client::Client;
 //! use std::env;
 //!
 //! fn main() {


### PR DESCRIPTION
Would also replace `Result` with `::std::result::Result` but that's already in #46.